### PR TITLE
feat: add email inbox integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project provides a FastAPI-based auto-responder for managing a master email
 - Store contacts with name, email, source type, marketing intent, and social media links.
 - List all contacts or filter by `source_type` and `marketing_intent`.
 - Endpoint stub for sending an auto-response to a contact.
+- Fetch email subjects from Gmail, ProtonMail, or a local MailHog server.
 - SQLite database for persistence.
 - Docker support for running the API and accessing the database separately.
 
@@ -16,18 +17,22 @@ This project provides a FastAPI-based auto-responder for managing a master email
    ```bash
    pip install -r requirements.txt
    ```
-2. Run the application:
+2. Set environment variables for any mail providers you wish to access:
+   - `GMAIL_USER` / `GMAIL_PASS`
+   - `PROTON_USER` / `PROTON_PASS` (optionally `PROTON_HOST`)
+   - `MAILHOG_BASE_URL` (defaults to `http://mailhog:8025`)
+3. Run the application:
    ```bash
    uvicorn main:app --reload
    ```
-3. The API will be available at `http://localhost:8000`.
+4. The API will be available at `http://localhost:8000`.
 
 ### Docker
 To run using Docker Compose:
 ```bash
 docker-compose up --build
 ```
-This starts the FastAPI app and a SQLite container that shares the database file via a volume.
+This starts the FastAPI app, a SQLite container, and a MailHog mail server that exposes SMTP on `1025` and a web UI on `8025`.
 
 ## Testing
 Run the unit tests with:
@@ -39,5 +44,8 @@ pytest
 - `POST /contacts` – add a contact to the master list.
 - `GET /contacts` – list contacts, optionally filtered by `source_type` and/or `marketing_intent`.
 - `POST /auto-responder/{contact_id}` – send an auto-response (placeholder) to a contact.
+- `GET /emails/gmail` – fetch recent Gmail emails.
+- `GET /emails/protonmail` – fetch recent ProtonMail emails.
+- `GET /emails/local` – fetch emails from the local MailHog server.
 
 The database file is stored under `data/rollodex.db` and can be accessed independently of the API.

--- a/app/email_utils.py
+++ b/app/email_utils.py
@@ -1,0 +1,37 @@
+import imaplib
+import email
+from email.header import decode_header
+from typing import List, Dict
+
+import httpx
+
+
+def fetch_imap_emails(host: str, username: str, password: str, folder: str = "INBOX", limit: int = 10) -> List[Dict[str, str]]:
+    """Fetch latest email subject lines from an IMAP server."""
+    with imaplib.IMAP4_SSL(host) as imap:
+        imap.login(username, password)
+        imap.select(folder)
+        status, messages = imap.search(None, "ALL")
+        if status != "OK":
+            return []
+        ids = messages[0].split()[-limit:]
+        results = []
+        for num in reversed(ids):
+            _, data = imap.fetch(num, "(RFC822)")
+            msg = email.message_from_bytes(data[0][1])
+            subject, encoding = decode_header(msg.get("Subject"))[0]
+            if isinstance(subject, bytes):
+                subject = subject.decode(encoding or "utf-8", errors="ignore")
+            results.append({"subject": subject})
+    return results
+
+
+def fetch_mailhog_emails(base_url: str = "http://mailhog:8025", limit: int = 10) -> List[Dict[str, str]]:
+    """Fetch email subjects from a MailHog server."""
+    resp = httpx.get(f"{base_url}/api/v2/messages")
+    resp.raise_for_status()
+    items = resp.json().get("items", [])[:limit]
+    return [
+        {"subject": item["Content"]["Headers"].get("Subject", [""])[0]}
+        for item in items
+    ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,8 @@ services:
     volumes:
       - ./data:/root/db
     tty: true
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -93,3 +93,31 @@ def test_auto_responder(client):
     resp = client.post(f"/auto-responder/{contact_id}")
     assert resp.status_code == 200
     assert "Auto-response sent" in resp.json()["message"]
+
+
+def test_gmail_endpoint(client, monkeypatch):
+    sample = [{"subject": "Hello"}]
+    monkeypatch.setenv("GMAIL_USER", "user")
+    monkeypatch.setenv("GMAIL_PASS", "pass")
+    monkeypatch.setattr("app.main.fetch_imap_emails", lambda host, username, password, folder="INBOX", limit=10: sample)
+    resp = client.get("/emails/gmail")
+    assert resp.status_code == 200
+    assert resp.json() == sample
+
+
+def test_proton_endpoint(client, monkeypatch):
+    sample = [{"subject": "Hi"}]
+    monkeypatch.setenv("PROTON_USER", "user")
+    monkeypatch.setenv("PROTON_PASS", "pass")
+    monkeypatch.setattr("app.main.fetch_imap_emails", lambda host, username, password, folder="INBOX", limit=10: sample)
+    resp = client.get("/emails/protonmail")
+    assert resp.status_code == 200
+    assert resp.json() == sample
+
+
+def test_local_email_endpoint(client, monkeypatch):
+    sample = [{"subject": "Local"}]
+    monkeypatch.setattr("app.main.fetch_mailhog_emails", lambda base_url, limit=10: sample)
+    resp = client.get("/emails/local")
+    assert resp.status_code == 200
+    assert resp.json() == sample


### PR DESCRIPTION
## Summary
- add Gmail, ProtonMail, and local MailHog endpoints
- support fetching IMAP and MailHog messages
- start MailHog container in docker compose and document usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a159c7109c8326b6507b6264ee5f45