### PR TITLE
Add campaign scheduling with variable touchpoints

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, ForeignKey, Float
 from sqlalchemy.dialects.sqlite import JSON
+from sqlalchemy.orm import relationship
 
 from .database import Base
 
@@ -13,3 +14,24 @@ class Contact(Base):
     source_type = Column(String, index=True)
     marketing_intent = Column(String, index=True)
     social_media = Column(JSON, nullable=True)
+
+
+class Campaign(Base):
+    __tablename__ = "campaigns"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    touchpoints = relationship(
+        "CampaignTouchpoint", back_populates="campaign", cascade="all, delete-orphan"
+    )
+
+
+class CampaignTouchpoint(Base):
+    __tablename__ = "campaign_touchpoints"
+
+    id = Column(Integer, primary_key=True, index=True)
+    campaign_id = Column(Integer, ForeignKey("campaigns.id"), nullable=False)
+    subject = Column(String, nullable=False)
+    body = Column(String, nullable=False)
+    delay_seconds = Column(Float, nullable=False, default=0)
+    campaign = relationship("Campaign", back_populates="touchpoints")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 from pydantic import BaseModel, EmailStr
 
 
@@ -16,6 +16,39 @@ class ContactCreate(ContactBase):
 
 class Contact(ContactBase):
     id: int
+
+    class Config:
+        orm_mode = True
+
+
+class CampaignTouchpointBase(BaseModel):
+    subject: str
+    body: str
+    delay_seconds: float
+
+
+class CampaignTouchpointCreate(CampaignTouchpointBase):
+    pass
+
+
+class CampaignTouchpoint(CampaignTouchpointBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+
+class CampaignBase(BaseModel):
+    name: str
+
+
+class CampaignCreate(CampaignBase):
+    touchpoints: List[CampaignTouchpointCreate]
+
+
+class Campaign(CampaignBase):
+    id: int
+    touchpoints: List[CampaignTouchpoint] = []
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
## Summary
- support creating email campaigns with multiple timed touchpoints
- add scheduling helpers to deliver campaign emails over variable delays
- test campaign run and ensure emails send in sequence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a160ad91788326b154378cb1b13177